### PR TITLE
Share URL parameter displayName not being honored

### DIFF
--- a/src/pages/share/[username].tsx
+++ b/src/pages/share/[username].tsx
@@ -7,7 +7,7 @@ import Link from 'next/link'
 
 import ContributionsGraph from '../../components/ContributionsGraph'
 import Layout from '../../components/Layout'
-import type { ErrorData, GraphData, GraphSettings, GraphSize, Themes } from '../../types'
+import type { ErrorData, GraphData, GraphSettings, GraphSize, Themes, DisplayName } from '../../types'
 
 interface Props {
   username: string
@@ -101,8 +101,9 @@ UserSharePage.getInitialProps = ({ query }) => {
 
   const size = typeof query.size === 'string' ? (query.size as GraphSize) : undefined
   const theme = typeof query.theme === 'string' ? (query.theme as Themes) : undefined
+  const displayName = typeof query.displayName === 'string' ? (query.displayName as DisplayName) : undefined
 
-  return { username, settings: { size, theme } }
+  return { username, settings: { size, theme, displayName } }
 }
 
 UserSharePage.getLayout = (page: React.ReactElement) => {

--- a/src/pages/share/[username].tsx
+++ b/src/pages/share/[username].tsx
@@ -7,7 +7,14 @@ import Link from 'next/link'
 
 import ContributionsGraph from '../../components/ContributionsGraph'
 import Layout from '../../components/Layout'
-import type { ErrorData, GraphData, GraphSettings, GraphSize, Themes, DisplayName } from '../../types'
+import type {
+  DisplayName,
+  ErrorData,
+  GraphData,
+  GraphSettings,
+  GraphSize,
+  Themes,
+} from '../../types'
 
 interface Props {
   username: string
@@ -101,7 +108,8 @@ UserSharePage.getInitialProps = ({ query }) => {
 
   const size = typeof query.size === 'string' ? (query.size as GraphSize) : undefined
   const theme = typeof query.theme === 'string' ? (query.theme as Themes) : undefined
-  const displayName = typeof query.displayName === 'string' ? (query.displayName as DisplayName) : undefined
+  const displayName =
+    typeof query.displayName === 'string' ? (query.displayName as DisplayName) : undefined
 
   return { username, settings: { size, theme, displayName } }
 }


### PR DESCRIPTION
## Issue
Share URL parameter `displayName` not being honored

## Type
Bug

## Description 
When a share URL is generated with `displayName=1`, it means that the username displayed should be Github's name and not the username. But when we copy the generated link in a new tab, even if the `displayName=1`, we are still showing the username which is wrong 

## Solution 
On the share page, along with `size` and `theme`, I have added `displayName` as it was missing. 
In the URL generation, we are using  `size`, `theme`, and `displayName`

## Use case validated
1. By default, the username should be shown
2. When the URL parameter has `displayName=1`, we need to display the name

## Screenshots

### Issue
<img width="1328" alt="Screenshot 2022-12-31 at 12 48 27 AM" src="https://user-images.githubusercontent.com/19502016/210105170-4d36eb81-c4b4-4788-b3ee-2945213a7830.png">

### Fix
<img width="1430" alt="Screenshot 2022-12-31 at 12 48 46 AM" src="https://user-images.githubusercontent.com/19502016/210105188-bfe21c65-77de-4766-b65d-0ca5b1f7b77b.png">

