### PR TITLE
fix: 移动端搜索框不居中

### DIFF
--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -119,7 +119,7 @@ export function SearchInput({
       onOpenChange={handleOpenChange}
       onValueChange={handleValueChange}
     >
-      <div className="relative">
+      <div className="relative w-2/3 md:w-[240px]">
         <AutocompleteInput
           ref={inputRef}
           data-1p-ignore
@@ -130,7 +130,7 @@ export function SearchInput({
           {...props}
           required
           className={cn(
-            'h-[2.8rem] w-2/3 md:w-[240px]',
+            'h-[2.8rem] w-full',
             '**:data-[slot=autocomplete-input]:placeholder:text-center **:data-[slot=autocomplete-input]:placeholder:font-normal',
             '**:data-[slot=autocomplete-input]:text-base **:data-[slot=autocomplete-input]:font-semibold **:data-[slot=autocomplete-input]:text-center',
             props.className,


### PR DESCRIPTION
修复前
<img width="668" height="1149" alt="image" src="https://github.com/user-attachments/assets/d0bd9f50-5b24-4772-8fb6-c6a42d6bef7a" />

修复后
<img width="1260" height="2800" alt="cd2fe84cebcd90b288bae7289c5bee0c" src="https://github.com/user-attachments/assets/c5ad7605-22a5-4537-9ecb-b0b4bad6a601" />
